### PR TITLE
WIP: Speed up API queries

### DIFF
--- a/datastore/models.py
+++ b/datastore/models.py
@@ -19,6 +19,7 @@ from datetime import timedelta, datetime
 import numpy as np
 import json
 from collections import defaultdict
+import itertools
 
 FUEL_TYPE_CHOICES = [
     ('E', 'electricity'),
@@ -55,6 +56,47 @@ class ProjectOwner(models.Model):
     def __str__(self):
         return u'ProjectOwner {}'.format(self.user.username)
 
+class ProjectManager(models.Manager):
+
+    def recent_meter_runs(self, project_pks=[]):
+        from django.db import connection
+        cursor = connection.cursor()
+
+        meter_runs = ''' 
+          SELECT DISTINCT ON (meter.consumption_metadata_id)
+            meter.*
+          FROM datastore_meterrun AS meter
+          JOIN datastore_project AS project
+            ON meter.project_id = project.id
+        '''
+        
+        qargs = []
+
+        if project_pks:
+            meter_runs = ''' 
+              {}
+              WHERE project.id IN %s
+            '''.format(meter_runs)
+            qargs.append(tuple(project_pks))
+
+        meter_runs = ''' 
+          {}
+          ORDER BY meter.consumption_metadata_id,
+            meter.added DESC
+        '''.format(meter_runs)
+        
+        cursor.execute(meter_runs, qargs)
+        
+        columns = [col[0] for col in cursor.description]
+        
+        results = []
+        for row in cursor.fetchall():
+            results.append(MeterRun(**dict(zip(columns, row))))
+
+        return results
+
+    def attributes(self):
+        return self.projectattribute_set
 
 @python_2_unicode_compatible
 class Project(models.Model):
@@ -70,6 +112,9 @@ class Project(models.Model):
     longitude = models.FloatField(blank=True, null=True)
     added = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
+
+    #objects = models.Manager()
+    objects = ProjectManager()
 
     def __str__(self):
         return u'Project {}'.format(self.project_id)
@@ -256,19 +301,68 @@ class Project(models.Model):
                 monthly_average_usage_reporting.save()
 
         return meter_runs
+    
+    @staticmethod
+    def recent_meter_runs(project_pks=[]):
 
-    def recent_meter_runs(self):
-        consumption_metadatas = self.consumptionmetadata_set.all()
-        meter_runs = []
-        for cm in consumption_metadatas:
-            try:
-                meter_runs.append(cm.meterrun_set.latest('added'))
-            except MeterRun.DoesNotExist:
-                pass
-        return meter_runs
+        from django.db import connection
+        cursor = connection.cursor()
 
-    def attributes(self):
-        return self.projectattribute_set.all()
+        meter_runs = ''' 
+          SELECT DISTINCT ON (consumption.id)
+            project.id,
+            consumption.id,
+            meter.*,
+            consumption.fuel_type
+          FROM datastore_meterrun AS meter
+          JOIN datastore_consumptionmetadata AS consumption
+            ON meter.consumption_metadata_id = consumption.id
+          JOIN datastore_project AS project
+            ON meter.project_id = project.id
+        '''
+        
+        qargs = []
+
+        if project_pks:
+            meter_runs = ''' 
+              {}
+              WHERE project.id IN %s
+            '''.format(meter_runs)
+            qargs.append(tuple(project_pks))
+
+        meter_runs = ''' 
+          {}
+          ORDER BY consumption.id,
+            meter.added DESC
+        '''.format(meter_runs)
+        
+        cursor.execute(meter_runs, qargs)
+        
+        meterrun_columns = [col[0] for col in cursor.description[2:-1]]
+        
+        results = {}
+        for consumption_id, rows in itertools.groupby(cursor.fetchall(), key=lambda x: x[1]):
+            
+            grouped_rows = list(rows)
+            results[grouped_rows[0][0]] = [{
+                'meterrun': MeterRun(**dict(zip(meterrun_columns, row[2:-1]))),
+                'fuel_type': row[-1]
+            } for row in grouped_rows]
+
+        return results
+    # def recent_meter_runs(self):
+    #     consumption_metadatas = self.consumptionmetadata_set.all()
+    #     meter_runs = []
+    #     for cm in consumption_metadatas:
+    #         try:
+    #             meter_runs.append(cm.meterrun_set.latest('added'))
+    #         except MeterRun.DoesNotExist:
+    #             pass
+    #     return meter_runs
+
+    # def attributes(self):
+    #     return self.projectattribute_set.all()
+
 
 
 @python_2_unicode_compatible

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -4,6 +4,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework import filters
 from rest_framework_bulk import BulkModelViewSet
+from rest_framework.parsers import BaseParser
 
 import django_filters
 
@@ -129,11 +130,31 @@ class ProjectFilter(django_filters.FilterSet):
 
 class ProjectViewSet(viewsets.ModelViewSet):
 
+    # parser_classes = (ProjectViewSetParser,)
     permission_classes = default_permissions_classes
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = ProjectFilter
-    queryset = models.Project.objects.all().order_by('pk')
 
+    def get_queryset(self):
+        return models.Project.objects.all()\
+                                     .prefetch_related('consumptionmetadata_set')\
+                                     .prefetch_related('projectattribute_set')\
+                                     .order_by('pk')
+
+    
+    def get_serializer(self, *args, **kwargs):
+        context = {'project_ids': []}
+        queryset = self.get_queryset()
+
+        if hasattr(self.request, 'query_params'):
+            
+            if self.request.query_params.get('projects'):
+                context['project_ids'] = self.request.query_params['projects'].split(' ')
+                queryset = queryset.filter(pk__in=context['project_ids'])
+
+        serializer_class = self.get_serializer_class()
+        return serializer_class(queryset, context=context, many=True)
+    
     def get_serializer_class(self):
         if not hasattr(self.request, 'query_params'):
             return serializers.ProjectSerializer


### PR DESCRIPTION
This is a stab at speeding up the queries needed to return results from the project API end points. One major caveat as the code is written right now is that the SQL I have in there is PostgreSQL specific. We can probably make it more generic but I just wanted to place this flag in the ground and see if this seems like an approach that we're into.

One major improvement is that the number of queries to return projects with attributes and meterruns is down to 8 all the time (no matter how many projects you want) and tends to return results within about 2 or 3 seconds when you're requesting everything.