### PR TITLE
Coerce possible int fields to str

### DIFF
--- a/datastore/views.py
+++ b/datastore/views.py
@@ -211,7 +211,7 @@ class ConsumptionMetadataViewSet(SyncMixin, viewsets.ModelViewSet):
 
     def _find_foreign_objects(self, record):
 
-        project = self.project_dict.get(record["project_project_id"])
+        project = self.project_dict.get(str(record["project_project_id"]))
         if project is None:
             return {
                 "status": "error - no Project found",
@@ -289,7 +289,7 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
 
     def _find_foreign_objects(self, record):
 
-        cm = self.metadata_dict.get((record["project_id"], record["fuel_type"]))
+        cm = self.metadata_dict.get((str(record["project_id"]), record["fuel_type"]))
         if cm is None:
             return {
                 "status": "error - no consumption metadata",

--- a/oeem_energy_datastore/settings.py
+++ b/oeem_energy_datastore/settings.py
@@ -114,7 +114,7 @@ LOGGING = {
     },
     'handlers': {
         'console': {
-            'level': 'DEBUG',
+            'level': 'INFO',
             'filters': ['require_debug_true'],
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'


### PR DESCRIPTION
Fixes a bug where a customer parser was sending int project ids which failed to match existing projects in the datastore.