### PR TITLE
Bulk sync

### DIFF
--- a/datastore/serializers/__init__.py
+++ b/datastore/serializers/__init__.py
@@ -140,7 +140,7 @@ class ConsumptionRecordSerializer(serializers.ModelSerializer):
 
 class ConsumptionMetadataSummarySerializer(serializers.ModelSerializer):
 
-    project = ProjectSerializer()
+    project = ProjectSerializer(required=False)
 
     class Meta:
         model = models.ConsumptionMetadata

--- a/datastore/serializers/__init__.py
+++ b/datastore/serializers/__init__.py
@@ -140,6 +140,8 @@ class ConsumptionRecordSerializer(serializers.ModelSerializer):
 
 class ConsumptionMetadataSummarySerializer(serializers.ModelSerializer):
 
+    project = ProjectSerializer()
+
     class Meta:
         model = models.ConsumptionMetadata
         fields = ('id', 'fuel_type', 'energy_unit', 'project')

--- a/datastore/services/__init__.py
+++ b/datastore/services/__init__.py
@@ -38,3 +38,4 @@ views.py
 
 from .overview import overview
 from .meterruns_export import meterruns_export
+from .bulk_sync import bulk_sync

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -8,32 +8,33 @@ def bulk_sync(records, fields, model_class, keys):
     """
     Upsert data for the given `model_class` using a temporary table.
 
-        records: list of dicts with data to insert
+    Parameters
+    ----------
+    records: list of dicts with data to insert
 
-            Example:
+        Example:
 
-            [{
-                start: 2016-01-01,
-                value: 10.0,
-                project_id: 1
-            }]
+        [{
+            start: 2016-01-01,
+            value: 10.0,
+            project_id: 1
+        }]
 
-        fields: list of fields expected to import
+    fields: list of fields expected to import
 
-            Example:
+        Example:
 
-                ['start', 'value', 'project_id']
+        ['start', 'value', 'project_id']
 
-        model_class: Django model class
+    model_class: Django model class
 
-        keys: primary or composite key
+    keys: primary or composite key
 
-            Examples:
+        Examples:
 
-            ['id']
+        ['id']
 
-            ['start', 'project_id']
-
+        ['start', 'project_id']
     """
 
     # Build schema from field names

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -2,6 +2,7 @@ import uuid
 import csv
 import logging
 import traceback
+import re
 try:
     from StringIO import StringIO
 except ImportError:
@@ -79,7 +80,7 @@ def bulk_sync(records, fields, model_class, keys):
     cursor = connection.cursor()
 
     # Create temporary table
-    tmp_id = str(uuid.uuid4()).translate(None, '-')
+    tmp_id = re.sub("-", "", str(uuid.uuid4()))
     tablename = model_class._meta.db_table
     tmp_tablename = "tmp_" + tablename + "_" + tmp_id
 

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -15,9 +15,10 @@ def success_response():
         "status": "success"
     }, 200)
 
-def error_response():
+def error_response(message="Error attempting to sync"):
     return ({
-        "status": "error"
+        "status": "error",
+        "message": message
     }, 400)
 
 def bulk_sync(records, fields, model_class, keys):
@@ -65,7 +66,6 @@ def bulk_sync(records, fields, model_class, keys):
     for record in records:
         if not valid_record(record):
             return error_response()
-
 
     # Build schema from field names
     schema = [

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -124,7 +124,6 @@ def bulk_sync(records, fields, model_class, keys):
     finally:
         cursor.close()
 
-    # TODO: smarter response. Maybe some sort of error check?
     return {
         "status": "success"
     }

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -7,14 +7,14 @@ import traceback
 from django.db import connection
 
 def success_response():
-    return {
+    return ({
         "status": "success"
-    }
+    }, 200)
 
 def error_response():
-    return {
+    return ({
         "status": "error"
-    }
+    }, 400)
 
 def bulk_sync(records, fields, model_class, keys):
     """

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -92,7 +92,7 @@ def bulk_sync(records, fields, model_class, keys):
     """.format(tmp_tablename=tmp_tablename, schema_statement=schema_statement)
 
     # Write the request data to an in-memory CSV file for a subsequent Postgres COPY
-    infile = StringIO.StringIO()
+    infile = StringIO()
     fieldnames = records[0].keys()
     writer = csv.DictWriter(infile, fieldnames=fieldnames)
     for record in records:

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -1,0 +1,128 @@
+import uuid
+import StringIO
+import csv
+
+from django.db import connection
+
+def bulk_sync(records, schema, model_class, keys):
+    """
+    Upsert data for the given `model_class` using a temporary table.
+
+        records: list of dicts with data to insert
+
+            Example:
+
+            [{
+                start: 2016-01-01,
+                value: 10.0,
+                project_id: 1
+            }]
+
+        schema: list of dicts with db field names and database types
+
+            Example:
+            [
+                {
+                    'name': 'start',
+                    'type': 'timestamp with time zone'
+                },
+                {
+                    'name': 'value',
+                    'type': 'double precision'
+                }
+            ]
+
+        model_class: Django model class
+
+        keys: primary or composite key
+
+            Examples:
+
+            ['id']
+
+            ['start', 'project_id']
+
+    """
+
+    # Bulk upsert, using (start, metadata_id) as primary key
+    cursor = connection.cursor()
+
+    # Create temporary table
+    tmp_id = str(uuid.uuid4()).translate(None, '-')
+    tablename = model_class._meta.db_table
+    tmp_tablename = "tmp_" + tablename + "_" + tmp_id
+
+    schema_statement = ",".join([
+      column['name'] + " " + column['type'] for column in schema
+    ])
+
+    create_tmp_table_statement = """
+      CREATE TEMPORARY TABLE {tmp_tablename}({schema_statement});
+    """.format(tmp_tablename=tmp_tablename, schema_statement=schema_statement)
+
+    # Write the request data to an in-memory CSV file for a subsequent Postgres COPY
+    infile = StringIO.StringIO()
+    fieldnames = records[0].keys()
+    writer = csv.DictWriter(infile, fieldnames=fieldnames)
+    for record in records:
+        writer.writerow(record)
+    infile.seek(0)
+
+    # Build SQL statement for upsert from temporary table to real table
+    update_schema_statement = ",".join([
+      "{name} = {tmp_tablename}.{name}".format(name=column['name'], tmp_tablename=tmp_tablename) for column in schema
+    ])
+
+    insert_columns = ",".join([
+      column['name'] for column in schema
+    ])
+
+    insert_schema_statement = ",".join([
+      "{tmp_tablename}.{name}".format(name=column['name'], tmp_tablename=tmp_tablename) for column in schema
+    ])
+
+    key_statement = " AND ".join([
+        "{tablename}.{key} = {tmp_tablename}.{key}".format(tablename=tablename, tmp_tablename=tmp_tablename, key=key)
+        for key in keys
+    ])
+
+    where_statement = " AND ".join([
+        "{tablename}.{key} IS NULL".format(tablename=tablename, key=key)
+        for key in keys
+    ])
+
+    upsert_statement = """
+      UPDATE {tablename}
+      SET {update_schema_statement}
+      FROM {tmp_tablename}
+      WHERE {key_statement};
+
+      INSERT INTO {tablename}({insert_columns})
+      SELECT {insert_schema_statement}
+      FROM {tmp_tablename}
+      LEFT OUTER JOIN {tablename} ON {key_statement}
+      WHERE {where_statement};
+    """.format(tablename=tablename,
+               tmp_tablename=tmp_tablename,
+               key_statement=key_statement,
+               where_statement=where_statement,
+               update_schema_statement=update_schema_statement,
+               insert_columns=insert_columns,
+               insert_schema_statement=insert_schema_statement)
+
+    try:
+        # Create the temporary table
+        cursor.execute(create_tmp_table_statement)
+
+        # Load data into temporary table from CSV
+        cursor.copy_from(file=infile, table=tmp_tablename, sep=',', columns=fieldnames)
+
+        # Upsert it into the actual table
+        cursor.execute(upsert_statement)
+    finally:
+        cursor.close()
+
+    # TODO: smarter response. Maybe some sort of error check?
+    return {
+        "status": "success"
+    }

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -1,8 +1,11 @@
 import uuid
-import StringIO
 import csv
 import logging
 import traceback
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from django.db import connection
 

--- a/datastore/services/bulk_sync.py
+++ b/datastore/services/bulk_sync.py
@@ -149,7 +149,7 @@ def bulk_sync(records, fields, model_class, keys):
         cursor.execute(create_tmp_table_statement)
 
         # Load data into temporary table from CSV
-        cursor.copy_from(file=infile, table=tmp_tablename, sep=',', columns=fieldnames)
+        cursor.copy_from(file=infile, table=tmp_tablename, sep=',', columns=fieldnames, null="")
 
         # Upsert it into the actual table
         cursor.execute(upsert_statement)

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -136,7 +136,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
             "estimated": False,
             "value": 1.0
         }])
-        assert response.status_code == 200
+        assert response.status_code == 400
         assert response.data['status'] == 'error'
 
         # Invalid `value` should return an error status
@@ -146,6 +146,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
             "estimated": False,
             "value": "foo"
         }])
+        assert response.status_code == 400
         assert response.data['status'] == 'error'
 
 

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -17,6 +17,41 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         )
         self.consumption_metadata.save()
 
+    def test_consumption_record_sync(self):
+
+        response = self.post('/api/v1/consumption_metadatas/sync/', [{
+            "project_project_id": "ABC",
+            "energy_unit": "KWH",
+            "fuel_type": "E"
+        }])
+
+        assert response.data[0]['status'] == 'created'
+        cm_id = response.data[0]['id']
+
+        response = self.post('/api/v1/consumption_records/sync/', [{
+            "project_id": "ABC",
+            "energy_unit": "KWH",
+            "fuel_type": "E",
+            "start": "2014-01-01T00:00:00+00:00",
+            "end": "2014-01-01T01:00:00+00:00",
+            "value": 1.0,
+            "estimated": True
+        }, {
+            "project_id": "ABC",
+            "energy_unit": "KWH",
+            "fuel_type": "E",
+            "start": "2014-01-01T01:00:00+00:00",
+            "end": "2014-01-01T02:00:00+00:00",
+            "value": 2.0,
+            "estimated": True
+        }])
+
+
+        assert response.data[0]['status'] == 'created'
+        assert response.data[0]['metadata'] == cm_id
+        assert response.data[1]['metadata'] == cm_id
+
+
     def test_consumption_record_create_read(self):
         data = [{
             "start": "2014-01-01T00:00:00+00:00",
@@ -45,3 +80,4 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert response.data['value'] == 0.0
         assert response.data['estimated'] == False
         assert response.data['metadata'] == self.consumption_metadata.pk
+

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -127,6 +127,15 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert c is not None
         assert c.value == 4.0
 
+        # Sending a dict instead of a list should be handled gracefully
+        response = self.post('/api/v1/consumption_records/sync2/', {
+            "start": start_a,
+            "metadata_id": cm_id,
+            "estimated": False,
+            "value": 1.0
+        })
+        assert response.status_code == 200
+
 
         # Test some invalid records
 

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -93,16 +93,27 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert a is not None
         assert b is not None
 
-        # Test updating
+        # Test updating and adding
+        start_c = "2014-01-01T02:00:00+00:00"
+
         response = self.post('/api/v1/consumption_records/sync2/', [{
             "metadata_id": cm_id,
             "start": start_a,
             "value": 3.0,
-            "estimated": True
+            "estimated": False
+        }, {
+            "metadata_id": cm_id,
+            "start": start_c,
+            "value": 4.0,
+            "estimated": False
         }])
 
         a = get_test_record_by_start(start_a)
         assert a.value == 3.0
+
+        c = get_test_record_by_start(start_c)
+        assert c.value == 4.0
+        assert c.estimated == False
 
         # Test metadata_id keys properly
         response = self.post('/api/v1/consumption_records/sync2/', [{

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -128,6 +128,27 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert c.value == 4.0
 
 
+        # Test some invalid records
+
+        # Missing field `start` should error out
+        response = self.post('/api/v1/consumption_records/sync2/', [{
+            "metadata_id": cm_id,
+            "estimated": False,
+            "value": 1.0
+        }])
+        assert response.status_code == 200
+        assert response.data['status'] == 'error'
+
+        # Invalid `value` should return an error status
+        response = self.post('/api/v1/consumption_records/sync2/', [{
+            "metadata_id": cm_id,
+            "start": start_a,
+            "estimated": False,
+            "value": "foo"
+        }])
+        assert response.data['status'] == 'error'
+
+
     def test_consumption_record_create_read(self):
         data = [{
             "start": "2014-01-01T00:00:00+00:00",

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -48,7 +48,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert response.data[0]['metadata'] == cm_id
         assert response.data[1]['metadata'] == cm_id
 
-    def test_consumption_record_bulk_sync(self):
+    def test_consumption_record_sync2(self):
 
         # Create a two metadata objects
         response = self.post('/api/v1/consumption_metadatas/sync/', [{
@@ -75,7 +75,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert a is None
         assert b is None
 
-        response = self.post('/api/v1/consumption_records/bulk_sync/', [{
+        response = self.post('/api/v1/consumption_records/sync2/', [{
             "metadata_id": cm_id,
             "start": start_a,
             "value": 1.0,
@@ -94,7 +94,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert b is not None
 
         # Test updating
-        response = self.post('/api/v1/consumption_records/bulk_sync/', [{
+        response = self.post('/api/v1/consumption_records/sync2/', [{
             "metadata_id": cm_id,
             "start": start_a,
             "value": 3.0,
@@ -105,7 +105,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         assert a.value == 3.0
 
         # Test metadata_id keys properly
-        response = self.post('/api/v1/consumption_records/bulk_sync/', [{
+        response = self.post('/api/v1/consumption_records/sync2/', [{
             "metadata_id": cm_id2,
             "start": start_a,
             "value": 4.0,

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -75,7 +75,7 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         # assert response.data[0]['status'] == 'created'
         # assert response.data[0]['metadata'] == cm_id
         # assert response.data[1]['metadata'] == cm_id
-        assert True
+        assert False
 
 
     def test_consumption_record_create_read(self):

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -136,6 +136,18 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
         })
         assert response.status_code == 200
 
+        # A null `value` should be supported
+        response = self.post('/api/v1/consumption_records/sync2/', [{
+            "start": start_a,
+            "metadata_id": cm_id,
+            "estimated": False,
+            "value": None
+        }])
+        assert response.status_code == 200
+        a = get_test_record_by_start(start_a)
+        assert a is not None
+        assert a.value is None
+
 
         # Test some invalid records
 

--- a/datastore/tests/views/test_consumption_record.py
+++ b/datastore/tests/views/test_consumption_record.py
@@ -33,7 +33,6 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
             "energy_unit": "KWH",
             "fuel_type": "E",
             "start": "2014-01-01T00:00:00+00:00",
-            "end": "2014-01-01T01:00:00+00:00",
             "value": 1.0,
             "estimated": True
         }, {
@@ -41,15 +40,42 @@ class ConsumptionRecordAPITestCase(OAuthTestCase):
             "energy_unit": "KWH",
             "fuel_type": "E",
             "start": "2014-01-01T01:00:00+00:00",
-            "end": "2014-01-01T02:00:00+00:00",
             "value": 2.0,
             "estimated": True
         }])
 
-
         assert response.data[0]['status'] == 'created'
         assert response.data[0]['metadata'] == cm_id
         assert response.data[1]['metadata'] == cm_id
+
+    def test_consumption_record_bulk_sync(self):
+
+        response = self.post('/api/v1/consumption_metadatas/sync/', [{
+            "project_project_id": "ABC",
+            "energy_unit": "KWH",
+            "fuel_type": "E"
+        }])
+
+        assert response.data[0]['status'] == 'created'
+        cm_id = response.data[0]['id']
+
+
+        response = self.post('/api/v1/consumption_records/bulk_sync/', [{
+            "metadata_id": cm_id,
+            "start": "2014-01-01T00:00:00+00:00",
+            "value": 1.0,
+            "estimated": True
+        }, {
+            "metadata_id": cm_id,
+            "start": "2014-01-01T01:00:00+00:00",
+            "value": 2.0,
+            "estimated": True
+        }])
+
+        # assert response.data[0]['status'] == 'created'
+        # assert response.data[0]['metadata'] == cm_id
+        # assert response.data[1]['metadata'] == cm_id
+        assert True
 
 
     def test_consumption_record_create_read(self):

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -340,8 +340,9 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         fields = ['start', 'value', 'estimated', 'metadata_id']
 
         records = request.data
+
         # Filter out records with an empty `value` field, which breaks import
-        records = [record for record in records if record['value'] is not None]
+        records = [record for record in records if record.get('value', None) is not None]
 
         result = services.bulk_sync(records, fields, models.ConsumptionRecord, ['start', 'metadata_id'])
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -19,11 +19,11 @@ from oauth2_provider.ext.rest_framework import TokenHasReadWriteScope
 from . import models
 from . import serializers
 from . import tasks
+from . import services
 from collections import defaultdict
 from datetime import datetime
 
 from django.conf import settings
-from django.db import connection
 
 if settings.DEBUG:
     default_permissions_classes = [DjangoModelPermissionsOrAnonReadOnly]
@@ -334,15 +334,6 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
             ]
         """
 
-        # Bulk upsert, using (start, metadata_id) as primary key
-        cursor = connection.cursor()
-
-        # Create temporary table
-        import uuid
-        tmp_id = str(uuid.uuid4()).translate(None, '-')
-        tablename = models.ConsumptionRecord._meta.db_table
-        tmp_tablename = "tmp_" + tablename + "_" + tmp_id
-
         schema = [
             {
                 'name': 'start',
@@ -361,81 +352,17 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
                 'type': 'integer'
             }
         ]
-
         # TODO: assert that the schema hasn't changed.
-
-        schema_statement = ",".join([
-          column['name'] + " " + column['type'] for column in schema
-        ])
-
-        create_tmp_table_statement = """
-          CREATE TEMPORARY TABLE {tmp_tablename}({schema_statement});
-        """.format(tmp_tablename=tmp_tablename, schema_statement=schema_statement)
 
         records = request.data
 
-        # Write the request data to an in-memory CSV file for a subsequent Postgres COPY
-        import StringIO
-        import csv
-        infile = StringIO.StringIO()
-        fieldnames = records[0].keys()
-        writer = csv.DictWriter(infile, fieldnames=fieldnames)
-        for record in records:
-            # Empty value break the import. Skip them.
-            if record['value'] is None:
-                continue
-            writer.writerow(record)
-        infile.seek(0)
+        # Filter out records with an empty `value` field, which breaks import
+        records = [record for record in records if record['value'] is not None]
 
-        # Build SQL statement for upsert from temporary table to real table
-        update_schema_statement = ",".join([
-          "{name} = {tmp_tablename}.{name}".format(name=column['name'], tmp_tablename=tmp_tablename) for column in schema
-        ])
-
-        insert_columns = ",".join([
-          column['name'] for column in schema
-        ])
-
-        insert_schema_statement = ",".join([
-          "{tmp_tablename}.{name}".format(name=column['name'], tmp_tablename=tmp_tablename) for column in schema
-        ])
-
-        upsert_statement = """
-          UPDATE {tablename}
-          SET {update_schema_statement}
-          FROM {tmp_tablename}
-          WHERE {tablename}.start = {tmp_tablename}.start AND
-                {tablename}.metadata_id = {tmp_tablename}.metadata_id;
-
-          INSERT INTO {tablename}({insert_columns})
-          SELECT {insert_schema_statement}
-          FROM {tmp_tablename}
-          LEFT OUTER JOIN {tablename} ON {tablename}.start = {tmp_tablename}.start AND
-                                         {tablename}.metadata_id = {tmp_tablename}.metadata_id
-          WHERE {tablename}.start IS NULL AND
-                {tablename}.metadata_id IS NULL;
-        """.format(tablename=tablename,
-                   tmp_tablename=tmp_tablename,
-                   update_schema_statement=update_schema_statement,
-                   insert_columns=insert_columns,
-                   insert_schema_statement=insert_schema_statement)
-
-        try:
-            # Create the temporary table
-            cursor.execute(create_tmp_table_statement)
-
-            # Load data into temporary table from CSV
-            cursor.copy_from(file=infile, table=tmp_tablename, sep=',', columns=fieldnames)
-
-            # Upsert it into the actual table
-            cursor.execute(upsert_statement)
-        finally:
-            cursor.close()
+        result = services.bulk_sync(records, schema, models.ConsumptionRecord, ['start', 'metadata_id'])
 
         # TODO: smarter response. Maybe some sort of error check?
-        return Response({
-            "status": "success"
-        })
+        return Response(result)
 
 
 class ProjectFilter(django_filters.FilterSet):

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -210,7 +210,7 @@ class ConsumptionMetadataViewSet(SyncMixin, viewsets.ModelViewSet):
         self.project_dict = {p.project_id: p for p in models.Project.objects.all()}
     def _find_foreign_objects(self, record):
 
-        project = self.project_dict.get(record["project_project_id"])
+        project = self.project_dict.get(str(record["project_project_id"]))
         if project is None:
             return {
                 "status": "error - no Project found",
@@ -288,7 +288,7 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
 
     def _find_foreign_objects(self, record):
 
-        cm = self.metadata_dict.get((record["project_id"], record["fuel_type"]))
+        cm = self.metadata_dict.get((str(record["project_id"]), record["fuel_type"]))
         if cm is None:
             return {
                 "status": "error - no consumption metadata",

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -344,9 +344,9 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         # Filter out records with an empty `value` field, which breaks import
         records = [record for record in records if record.get('value', None) is not None]
 
-        result = services.bulk_sync(records, fields, models.ConsumptionRecord, ['start', 'metadata_id'])
+        result, status = services.bulk_sync(records, fields, models.ConsumptionRecord, ['start', 'metadata_id'])
 
-        return Response(result)
+        return Response(result, status=status)
 
 
 class ProjectFilter(django_filters.FilterSet):

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -345,7 +345,6 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
 
         result = services.bulk_sync(records, fields, models.ConsumptionRecord, ['start', 'metadata_id'])
 
-        # TODO: smarter response. Maybe some sort of error check?
         return Response(result)
 
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -347,6 +347,10 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
 
         records = request.data
 
+        # Wrap as list if missing
+        if type(records) is not list:
+            records = [records]
+
         # Filter out records with an empty `value` field, which breaks import
         records = [record for record in records if record.get('value', None) is not None]
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -384,6 +384,9 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         fieldnames = records[0].keys()
         writer = csv.DictWriter(infile, fieldnames=fieldnames)
         for record in records:
+            # Empty value break the import. Skip them.
+            if record['value'] is None:
+                continue
             writer.writerow(record)
         infile.seek(0)
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -369,13 +369,8 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         ])
 
         create_tmp_table_statement = """
-          CREATE TABLE {tmp_tablename}({schema_statement});
+          CREATE TEMPORARY TABLE {tmp_tablename}({schema_statement});
         """.format(tmp_tablename=tmp_tablename, schema_statement=schema_statement)
-
-        create_tmp_table_statement = """
-          DROP TABLE IF EXISTS {tmp_tablename};
-          {create_tmp_table_statement}
-        """.format(tmp_tablename=tmp_tablename, create_tmp_table_statement=create_tmp_table_statement)
 
         records = request.data
 
@@ -419,8 +414,6 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
                                          {tablename}.metadata_id = {tmp_tablename}.metadata_id
           WHERE {tablename}.start IS NULL AND
                 {tablename}.metadata_id IS NULL;
-
-          DROP TABLE IF EXISTS {tmp_tablename};
         """.format(tablename=tablename,
                    tmp_tablename=tmp_tablename,
                    update_schema_statement=update_schema_statement,

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -338,8 +338,10 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         cursor = connection.cursor()
 
         # Create temporary table
+        import uuid
+        tmp_id = str(uuid.uuid4()).translate(None, '-')
         tablename = models.ConsumptionRecord._meta.db_table
-        tmp_tablename = "tmp_" + tablename
+        tmp_tablename = "tmp_" + tablename + "_" + tmp_id
 
         schema = [
             {

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -208,10 +208,9 @@ class ConsumptionMetadataViewSet(SyncMixin, viewsets.ModelViewSet):
         ]
 
         self.project_dict = {p.project_id: p for p in models.Project.objects.all()}
-
     def _find_foreign_objects(self, record):
 
-        project = self.project_dict.get(str(record["project_project_id"]))
+        project = self.project_dict.get(record["project_project_id"])
         if project is None:
             return {
                 "status": "error - no Project found",
@@ -289,7 +288,7 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
 
     def _find_foreign_objects(self, record):
 
-        cm = self.metadata_dict.get((str(record["project_id"]), record["fuel_type"]))
+        cm = self.metadata_dict.get((record["project_id"], record["fuel_type"]))
         if cm is None:
             return {
                 "status": "error - no consumption metadata",
@@ -315,6 +314,12 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
     def _parse_record(self, record, foreign_objects):
         record["start"] = parse_datetime(record["start"])
         return record
+
+    @list_route(methods=['post'])
+    def bulk_sync(self, request):
+        # Retrieve metadata object
+        # Bulk upsert, using (start, metadata_id) as primary key
+        pass
 
 class ProjectFilter(django_filters.FilterSet):
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -283,8 +283,9 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         ]
 
         consumption_metadatas = models.ConsumptionMetadata.objects.all()
+
         self.metadata_dict = {(cm.project.project_id, cm.fuel_type): cm
-                         for cm in consumption_metadatas}
+                         for cm in consumption_metadatas if cm.project}
 
     def _find_foreign_objects(self, record):
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -68,12 +68,10 @@ class SyncMixin(object):
         response_data = [self._sync_record(record) for record in request.data]
 
         # Return a 400 response if any of the records failed to sync
-        #
-        # Convention is that "status" key is only returned during errors.
         status_code = 200
-        # for obj in response_data:
-        #     if "status" in obj:
-        #         status_code = 400
+        for obj in response_data:
+            if "error" in obj.get("status", ""):
+                status_code = 400
 
         return Response(response_data, status=status_code)
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -67,7 +67,15 @@ class SyncMixin(object):
 
         response_data = [self._sync_record(record) for record in request.data]
 
-        return Response(response_data)
+        # Return a 400 response if any of the records failed to sync
+        #
+        # Convention is that "status" key is only returned during errors.
+        status_code = 200
+        for obj in response_data:
+            if "status" in obj:
+                status_code = 400
+
+        return Response(response_data, status=status_code)
 
     def _sync_record(self, record):
         """ Get/Create/Update records as necessary, returing dict with data

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -318,9 +318,12 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         return record
 
     @list_route(methods=['post'])
-    def bulk_sync(self, request):
+    def sync2(self, request):
         """
-        `POST /api/v1/consumption_records/bulk_sync/`
+        `POST /api/v1/consumption_records/sync2/`
+
+        A much faster sync implementation. Slightly different behavior than the existing sync route in that
+        it expects a `metadata_id` rather than the metadata properties.
 
         Expects records like the following::
 
@@ -334,32 +337,13 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
             ]
         """
 
-        schema = [
-            {
-                'name': 'start',
-                'type': 'timestamp with time zone'
-            },
-            {
-                'name': 'value',
-                'type': 'double precision'
-            },
-            {
-                'name': 'estimated',
-                'type': 'boolean'
-            },
-            {
-                'name': 'metadata_id',
-                'type': 'integer'
-            }
-        ]
-        # TODO: assert that the schema hasn't changed.
+        fields = ['start', 'value', 'estimated', 'metadata_id']
 
         records = request.data
-
         # Filter out records with an empty `value` field, which breaks import
         records = [record for record in records if record['value'] is not None]
 
-        result = services.bulk_sync(records, schema, models.ConsumptionRecord, ['start', 'metadata_id'])
+        result = services.bulk_sync(records, fields, models.ConsumptionRecord, ['start', 'metadata_id'])
 
         # TODO: smarter response. Maybe some sort of error check?
         return Response(result)

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -71,9 +71,9 @@ class SyncMixin(object):
         #
         # Convention is that "status" key is only returned during errors.
         status_code = 200
-        for obj in response_data:
-            if "status" in obj:
-                status_code = 400
+        # for obj in response_data:
+        #     if "status" in obj:
+        #         status_code = 400
 
         return Response(response_data, status=status_code)
 

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -351,9 +351,6 @@ class ConsumptionRecordViewSet(SyncMixin, BulkModelViewSet):
         if type(records) is not list:
             records = [records]
 
-        # Filter out records with an empty `value` field, which breaks import
-        records = [record for record in records if record.get('value', None) is not None]
-
         result, status = services.bulk_sync(records, fields, models.ConsumptionRecord, ['start', 'metadata_id'])
 
         return Response(result, status=status)


### PR DESCRIPTION
Adds the route `consumption_records/sync2` route, which uses a much faster scheme for upserting data into the database.

The bulk upsert is factored out into a service that can be used for any table.

Numerous small tweaks and bug fixes included to allow the ETL runs to finish cleanly:

- ConsumptionMetadata sync returns the nested project so that the client has access to project.project_id
- Return  400 response if any sync fails in the old `sync` route


